### PR TITLE
[feature/3-delete-setup-app-version]: Delete setting of the AppVersion for all charts

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -44,9 +44,15 @@ jobs:
         uses: azure/setup-helm@v4.2.0
         with:
           version: v3.17.0
-      - name: Package charts
+      - name: Package Casdoor charts
         working-directory: charts
-        run: ls -d */ | xargs -I$ sh -c 'helm package $ -d build --app-version ${{  github.ref }}' && helm repo index build --url https://ptrvsrg.github.io/casdoor-operator/charts
+        run: helm package casdoor -d build
+      - name: Package Casdoor Operator charts
+        working-directory: charts
+        run: helm package casdoor-operator -d build --app-version ${{ github.ref }}
+      - name: Index charts
+        working-directory: charts
+        run: helm repo index build --url https://ptrvsrg.github.io/casdoor-operator/charts
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
The setting of the AppVersion is needed only for the Casdoor operator